### PR TITLE
Changed Convolution::processSingleSample to use auto command to fix c…

### DIFF
--- a/Source/Convolution.cpp
+++ b/Source/Convolution.cpp
@@ -79,13 +79,13 @@ void Convolution::processSingleSample(float* data, int i, int numSamples)
 {
     if (memory.size() != getFilterOrder())
         resetFifo();
-    std::vector<Eigen::RowVectorXf>::iterator fifo = memory.begin();
+    auto fifo = memory.begin();
     for (int ch = 0; ch < inputChannels; ++ch)
         (*(fifo+pos))[ch] = data[idx(ch, i, numSamples)];
     outVec.setZero();
     std::vector<Eigen::MatrixXf>::iterator it;
     int j = 0;
-    for (it = kernel.begin(); it != kernel.end(); it++)
+    for (auto it = kernel.begin(); it != kernel.end(); it++)
     {
         int readPos = mod((pos - j * dilation), getFilterOrder());
         outVec = outVec + *(fifo+readPos) * (*it);


### PR DESCRIPTION
…ompile in linux.  The diff view in github is showing 66 changed lines, but this is from VSCode automatically fixing line endings to be uniform. The only actual code changes are in line 82 and line 88.  Compilation was failing in Ubuntu linux due to invalid type conversion. Using the "auto" command allows the type to automatically be deduced by from the initializer.